### PR TITLE
Fix: Restructure tauri.conf.json for Tauri v2 compatibility

### DIFF
--- a/gita/src-tauri/tauri.conf.json
+++ b/gita/src-tauri/tauri.conf.json
@@ -1,56 +1,14 @@
 {
-  "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli/schema.json",
+  "productName": "Obsidian Replica",
+  "version": "0.1.0",
+  "identifier": "com.manus.obsidianreplica",
   "build": {
-    "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",
-    "devPath": "http://localhost:1420",
-    "distDir": "../dist"
+    "beforeDevCommand": "npm run dev",
+    "devUrl": "http://localhost:1420",
+    "frontendDist": "../dist"
   },
-  "package": {
-    "productName": "Obsidian Replica",
-    "version": "0.1.0"
-  },
-  "tauri": {
-    "allowlist": {
-      "all": false,
-      "shell": {
-        "all": false,
-        "open": true
-      },
-      "dialog": {
-        "all": true
-      },
-      "fs": {
-        "all": true,
-        "scope": ["$APP/*", "$DOCUMENT/*"]
-      },
-      "path": {
-        "all": true
-      },
-      "protocol": {
-        "asset": true,
-        "assetScope": ["$APP/*"]
-      }
-    },
-    "bundle": {
-      "active": true,
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ],
-      "identifier": "com.manus.obsidianreplica",
-      "targets": "all",
-      "category": "Productivity"
-    },
-    "security": {
-      "csp": null
-    },
-    "updater": {
-      "active": false
-    },
+  "app": {
     "windows": [
       {
         "fullscreen": false,
@@ -61,7 +19,44 @@
         "minWidth": 800,
         "minHeight": 600
       }
-    ]
-  }
+    ],
+    "security": {
+      "csp": null,
+      "allowlist": {
+        "all": false,
+        "shell": {
+          "all": false,
+          "open": true
+        },
+        "dialog": {
+          "all": true
+        },
+        "fs": {
+          "all": true,
+          "scope": ["$APP/*", "$DOCUMENT/*"]
+        },
+        "path": {
+          "all": true
+        },
+        "protocol": {
+          "asset": true,
+          "assetScope": ["$APP/*"]
+        }
+      }
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "category": "Productivity",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "createUpdaterArtifacts": false
+  },
+  "plugins": {}
 }
-


### PR DESCRIPTION
- I've updated tauri.conf.json to align with the Tauri v2 schema based on official documentation (tauri-cli 2.5.0).
- I removed the top-level `package` and `tauri` objects.
- I elevated `productName`, `version`, and `identifier` to be top-level properties.
- I restructured the `build` object at the top level, renaming `devPath` to `devUrl` and `distDir` to `frontendDist`.
- I created a top-level `app` object, moving `windows` configurations into `app.windows` and `security` (including `csp` and the previous `allowlist`) into `app.security`.
- I restructured the `bundle` object at the top level, including previous bundle settings and mapping `updater.active` to `bundle.createUpdaterArtifacts`.
- I added an empty `plugins: {}` object as per v2 structure.
- I removed the `$schema` key.

These changes address errors related to incorrect property placement and missing required properties for Tauri v2.