### PR TITLE
Refactor: Clean editor UI and rename application to Gita

### DIFF
--- a/gita/CHANGELOG.md
+++ b/gita/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release of Obsidian Replica
+- Initial release of Gita
 - Markdown editing with Lexical editor
 - Audio recording from microphone and system audio
 - Audio playback with timestamp linking

--- a/gita/CONTRIBUTING.md
+++ b/gita/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Obsidian Replica
+# Contributing to Gita
 
-Thank you for considering contributing to Obsidian Replica! This document provides guidelines and instructions for contributing to the project.
+Thank you for considering contributing to Gita! This document provides guidelines and instructions for contributing to the project.
 
 ## Code of Conduct
 

--- a/gita/index.html
+++ b/gita/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
+    <title>Gita</title>
   </head>
 
   <body class="bg-light-bg dark:bg-obsidian-bg text-light-text dark:text-obsidian-text">

--- a/gita/package.json
+++ b/gita/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "obsidian-replica",
+  "name": "gita",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/gita/src-tauri/tauri.conf.json
+++ b/gita/src-tauri/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "productName": "Obsidian Replica",
+  "productName": "Gita",
   "version": "0.1.0",
   "identifier": "com.ydnotes.gita",
   "build": {
@@ -13,7 +13,7 @@
       {
         "fullscreen": false,
         "resizable": true,
-        "title": "Obsidian Replica",
+        "title": "Gita",
         "width": 1200,
         "height": 800,
         "minWidth": 800,

--- a/gita/src/App.tsx
+++ b/gita/src/App.tsx
@@ -204,7 +204,6 @@ Start writing here...`;
               {/* Props for EditorContainer from jules_wip */}
               <EditorContainer
                 noteTitle={selectedNote.title}
-                onSave={handleSaveNote}
               >
                 {/* Props for LexicalEditor are consistent */}
                 <LexicalEditor 

--- a/gita/src/components/EditorContainer.tsx
+++ b/gita/src/components/EditorContainer.tsx
@@ -5,7 +5,6 @@ import { FiSave, FiLink, FiClock } from 'react-icons/fi';
 interface EditorContainerProps {
   noteTitle: string;
   // isRecording, onStartRecording, onStopRecording removed
-  onSave: () => void;
   children: React.ReactNode; // This will be LexicalEditor
 }
 
@@ -14,7 +13,6 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
   // isRecording, // Removed
   // onStartRecording, // Removed
   // onStopRecording, // Removed
-  onSave,
   children // LexicalEditor is passed here
 }) => {
   // To pass currentNoteId to LexicalEditor, we need to ensure children can accept it.
@@ -27,19 +25,9 @@ const EditorContainer: React.FC<EditorContainerProps> = ({
   return (
     <div className="flex flex-col h-screen"> {/* Outer container itself doesn't need a bg if App.tsx provides one */}
       {/* Editor header */}
-      <div className="flex items-center justify-between p-2 border-b border-light-border dark:border-obsidian-border bg-light-bg dark:bg-obsidian-bg">
+      <div className="flex items-center justify-start p-2 border-b border-light-border dark:border-obsidian-border bg-light-bg dark:bg-obsidian-bg">
         <div className="flex items-center">
           <h2 className="text-lg font-medium text-light-text dark:text-obsidian-text">{noteTitle}</h2>
-        </div>
-        <div className="flex items-center space-x-2">
-          {/* AudioRecorder component removed */}
-          <button 
-            className="p-1.5 rounded hover:bg-light-hover dark:hover:bg-obsidian-hover text-light-text dark:text-obsidian-text"
-            onClick={onSave}
-            title="Save"
-          >
-            <FiSave /> {/* Icon inherits color */}
-          </button>
         </div>
       </div>
 

--- a/gita/src/components/Sidebar.tsx
+++ b/gita/src/components/Sidebar.tsx
@@ -72,7 +72,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       {/* Sidebar header */}
       <div className="p-2 border-b border-light-border dark:border-obsidian-border">
         <div className="flex items-center justify-between mb-2">
-          <h1 className="text-lg font-semibold text-light-text dark:text-obsidian-text">Obsidian Replica</h1>
+          <h1 className="text-lg font-semibold text-light-text dark:text-obsidian-text">Gita</h1>
         </div>
         <div className="relative">
           <input


### PR DESCRIPTION
This commit implements the following changes based on your feedback:

1.  **Application Renaming**:
    - Renamed the application from "Obsidian Replica" to "Gita" across various user-facing parts of the application, including: - Sidebar header title. - `index.html` title tag. - `package.json` name. - `tauri.conf.json` productName and window title. - Relevant documentation files (CHANGELOG.md, CONTRIBUTING.md).

2.  **Editor Header Cleanup**:
    - Modified the header within the main editor view (`EditorContainer.tsx`) to only display the note title.
    - Removed the manual save button from this header to simplify the interface. Save functionality remains available via keyboard shortcuts (Ctrl+S).
    - Adjusted styling to ensure the note title aligns correctly to the left after the removal of other elements.

3.  **Editor Toolbar Review**:
    - Verified that the `EditorToolbar.tsx` already meets the requirement of having Markdown formatting (bold, italic, code, headings) and bullet/list functionality available by default. No changes were necessary for this part.

These changes contribute to a cleaner and more focused user interface for the editor and align the application's branding with the name "Gita".