### PR TITLE
feat: Integrate PostgreSQL for metadata storage

### DIFF
--- a/gita/src-tauri/Cargo.toml
+++ b/gita/src-tauri/Cargo.toml
@@ -16,7 +16,8 @@ tauri-build = { version = "2.0.0-beta", features = [] }
 tauri = { version = "2.0.0-beta", features = [ "protocol-asset"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.7", features = [ "runtime-tokio-rustls", "postgres", "uuid", "chrono", "json" ] }
+sqlx = { version = "0.7", features = [ "runtime-tokio-native-tls", "postgres", "uuid", "chrono", "json" ] }
+tokio = { version = "1", features = ["full"] }
 walkdir = "2.3.3"
 notify = "4.0.17"
 regex = "1.9.1"

--- a/gita/src-tauri/src/db.rs
+++ b/gita/src-tauri/src/db.rs
@@ -1,0 +1,11 @@
+use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::env;
+
+pub async fn init_pool() -> Result<PgPool, sqlx::Error> {
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await
+}


### PR DESCRIPTION
I've refactored the backend to use PostgreSQL.

Key changes:
- I added a new Rust module `db.rs` for managing PostgreSQL connections.
- I defined an `AppState` struct to hold `sqlx::PgPool`.
- I implemented `init_pool()` to initialize the connection pool from `DATABASE_URL`.
- I updated `main.rs` to initialize and manage the `PgPool` via Tauri's state.
- I modified `Cargo.toml` to include necessary dependencies (`sqlx` with `postgres` and `runtime-tokio-native-tls`, `tokio`).
- I commented out existing Tauri commands that were using the previous SQLite connection. These will be updated in a future commit.