### PR TITLE
Fix Rust warnings, DATABASE_URL panic, and Vite import error

### DIFF
--- a/gita/.gitignore
+++ b/gita/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+src-tauri/.env

--- a/gita/src-tauri/Cargo.toml
+++ b/gita/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ lazy_static = "1.4.0"
 ringbuf = "0.3.3"
 tauri-plugin-opener = "^2.0.0" # Added opener plugin
 uuid = { version = "1", features = ["v4"] }
+dotenvy = "0.15"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/gita/src-tauri/src/audio.rs
+++ b/gita/src-tauri/src/audio.rs
@@ -26,8 +26,6 @@ struct RecordingState {
     loopback_stream_thread: Option<JoinHandle<()>>,
     writer_thread: Option<JoinHandle<()>>,
     stop_signal: Arc<AtomicBool>,
-    mic_device_identifier: String, // Name or other unique ID
-    loopback_device_identifier: Option<String>, // Name or other unique ID
 }
 
 lazy_static::lazy_static! {
@@ -292,8 +290,7 @@ pub fn start_recording(page_id_opt: Option<&str>, recording_id: &str, audio_dir:
 
     // Configure Loopback
     let mut loopback_config_final: Option<StreamConfig> = None;
-    let mut loopback_actual_channels: Option<u16> = None;
-    let final_loopback_device_identifier = loopback_device_identifier.clone();
+    // let final_loopback_device_identifier = loopback_device_identifier.clone(); // Removed
 
     if let Some(ref dev) = loopback_device {
         let supported_loop_config = dev.default_input_config()
@@ -619,8 +616,8 @@ pub fn start_recording(page_id_opt: Option<&str>, recording_id: &str, audio_dir:
         loopback_stream_thread,
         writer_thread: Some(writer_thread),
         stop_signal,
-        mic_device_identifier, // Store the identifier
-        loopback_device_identifier: if loopback_actual_channels.is_some() { final_loopback_device_identifier } else { None }, // Store if loopback is active
+        // mic_device_identifier, // Store the identifier // Removed
+        // loopback_device_identifier: if loopback_actual_channels.is_some() { final_loopback_device_identifier } else { None }, // Store if loopback is active // Removed
     };
 
     let mut recordings_map = ACTIVE_RECORDINGS.lock().unwrap();

--- a/gita/src-tauri/src/file_system.rs
+++ b/gita/src-tauri/src/file_system.rs
@@ -32,23 +32,6 @@ impl Default for NoteFrontMatter {
     }
 }
 
-// Helper function to extract front matter from markdown content
-// Ensure this function does not have ::std::fs or other removed deps if they are not used
-// (it primarily uses string manipulation and regex)
-fn extract_front_matter(content: &str) -> (Option<String>, &str) {
-    let front_matter_regex = Regex::new(r"^(?s)---\s*
-(.*?)
----\s*
-?(.*)$").unwrap(); // Note: using (.*?) for non-greedy match on FM content
-    if let Some(caps) = front_matter_regex.captures(content) {
-        let fm_str = caps.get(1).map_or("", |m| m.as_str()).trim();
-        let rest_content = caps.get(2).map_or("", |m| m.as_str());
-        (Some(fm_str.to_string()), rest_content)
-    } else {
-        (None, content)
-    }
-}
-
 // All public functions (init_database, get_all_notes, search_notes, read_markdown_file,
 // write_markdown_file, create_note, create_daily_note, delete_note, find_backlinks)
 // and the public structs NoteMetadata and Note have been removed.

--- a/gita/src-tauri/src/main.rs
+++ b/gita/src-tauri/src/main.rs
@@ -12,6 +12,7 @@ pub mod block_handler;
 pub mod audio_handler;
 pub mod link_handler;
 
+use dotenvy;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{AppHandle, Manager, State};
@@ -502,6 +503,7 @@ async fn get_references_for_block(state: State<'_, AppState>, block_id: String) 
 
 #[tokio::main]
 async fn main() {
+    dotenvy::dotenv().ok();
     tauri::Builder::default()
     .setup(|app| {
         let app_handle = app.app_handle().clone();

--- a/gita/src-tauri/src/page_handler.rs
+++ b/gita/src-tauri/src/page_handler.rs
@@ -23,7 +23,6 @@ struct ExtractedBlockInfo {
 
 #[derive(Debug, Clone)]
 struct ParsedPageLink {
-    source_page_id: Uuid,
     target_title: Option<String>,
     target_id: Option<Uuid>,
     // If we need to identify which block a page link is in (e.g. for rich text editing later)
@@ -32,7 +31,6 @@ struct ParsedPageLink {
 
 #[derive(Debug, Clone)]
 struct ParsedBlockReference {
-    source_page_id: Uuid, // The page where this reference ((())) is made
     referencing_block_id: Uuid, // The block ID from content_json that contains the reference
     referenced_block_id: Uuid, // The block ID that is being pointed to
 }
@@ -359,9 +357,9 @@ fn extract_links_references_and_blocks(
                         for cap in PAGE_LINK_REGEX.captures_iter(text_content) {
                             let content = cap[1].trim().to_string();
                             if let Ok(target_uuid) = Uuid::parse_str(&content) {
-                                page_links.push(ParsedPageLink { source_page_id: current_page_id, target_id: Some(target_uuid), target_title: None });
+                                page_links.push(ParsedPageLink { target_id: Some(target_uuid), target_title: None });
                             } else {
-                                page_links.push(ParsedPageLink { source_page_id: current_page_id, target_id: None, target_title: Some(content) });
+                                page_links.push(ParsedPageLink { target_id: None, target_title: Some(content) });
                             }
                         }
 
@@ -371,7 +369,6 @@ fn extract_links_references_and_blocks(
                             for cap in BLOCK_REF_REGEX.captures_iter(text_content) {
                                 if let Ok(referenced_b_id) = Uuid::parse_str(cap[1].trim()) {
                                     block_references.push(ParsedBlockReference {
-                                        source_page_id: current_page_id,
                                         referencing_block_id: referencing_id,
                                         referenced_block_id: referenced_b_id,
                                     });

--- a/gita/src/App.tsx
+++ b/gita/src/App.tsx
@@ -22,7 +22,7 @@ import { FiHelpCircle, FiSettings } from "react-icons/fi";
 import Tooltip from "./components/Tooltip";
 import ErrorDisplay from './components/ErrorDisplay'; // Import ErrorDisplay
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'; // Import the new hook
-import { convertLexicalJSONToMarkdown } from "../utils/lexicalUtils"; // Added import
+import { convertLexicalJSONToMarkdown } from "./utils/lexicalUtils"; // Added import
 
 function App() {
   const [notes, setNotes] = useState<Note[]>([]);


### PR DESCRIPTION
This commit addresses several issues present in the initial error log:

1.  **Rust Warnings:**
    *   Removed unused variable `loopback_actual_channels` in `audio.rs`.
    *   Removed unused fields `mic_device_identifier` and `loopback_device_identifier` from `RecordingState` in `audio.rs`.
    *   Removed unused function `extract_front_matter` in `file_system.rs`.
    *   Removed unused field `source_page_id` from `ParsedPageLink` and `ParsedBlockReference` structs in `page_handler.rs`, and updated their instantiations.

2.  **DATABASE_URL Panic:**
    *   Added `dotenvy` to `src-tauri/Cargo.toml`.
    *   Modified `src-tauri/src/main.rs` to call `dotenvy::dotenv().ok();` at startup, enabling the loading of the `.env` file which should contain the `DATABASE_URL`.
    *   Added `src-tauri/.env` to `.gitignore` to prevent accidental committing of environment configuration.

3.  **Vite Import Error:**
    *   Corrected the import path for `convertLexicalJSONToMarkdown` in `src/App.tsx` from `../utils/lexicalUtils` to `./utils/lexicalUtils`.